### PR TITLE
Implement uptime and status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ While developing you can run `npm run dev` so the bot restarts automatically whe
 - `/ping` – the bot replies "Pong!" and shows how long the response took.
 - `/help` – sends a list with all commands.
 - `/giff` – posts a random GIF just for fun.
+- `/uptime` – shows how long the bot has been running.
+- `/status` – displays a simple online status with ping information.
 
 Have fun creating new commands!

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,0 +1,20 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+/**
+ * Defines the `/status` command.
+ * It displays a basic status message with the bot's ping.
+ * @type {import('discord.js').SlashCommandBuilder}
+ */
+export const data = new SlashCommandBuilder()
+  .setName('status')
+  .setDescription('Shows the bot status.');
+
+/**
+ * Runs when someone uses `/status`.
+ * @param {import('discord.js').CommandInteraction} interaction
+ * @returns {Promise<void>}
+ */
+export async function execute(interaction) {
+  const ping = interaction.client.ws.ping ?? 0;
+  await interaction.reply(`Online \u2705 Ping: ${ping}ms`);
+}

--- a/src/commands/uptime.js
+++ b/src/commands/uptime.js
@@ -1,0 +1,21 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+/**
+ * Defines the `/uptime` command.
+ * It shows how long the bot has been running in seconds.
+ * @type {import('discord.js').SlashCommandBuilder}
+ */
+export const data = new SlashCommandBuilder()
+  .setName('uptime')
+  .setDescription('Shows how long the bot has been running.');
+
+/**
+ * Runs when someone uses `/uptime`.
+ * @param {import('discord.js').CommandInteraction} interaction
+ * @returns {Promise<void>}
+ */
+export async function execute(interaction) {
+  const started = interaction.client.startTime ?? Date.now();
+  const uptime = Math.floor((Date.now() - started) / 1000);
+  await interaction.reply(`Bot uptime: ${uptime} seconds.`);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ const client = new Client({
     GatewayIntentBits.MessageContent
   ]
 });
+// Record the start time so commands like /uptime can use it
+client.startTime = Date.now();
 
 /** List of commands the bot knows. */
 const commands = [];

--- a/tests/commands/status.test.js
+++ b/tests/commands/status.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+import { execute } from '../../src/commands/status.js';
+
+describe('status command', () => {
+  test('responds with online message and ping', async () => {
+    const interaction = {
+      client: { ws: { ping: 123 } },
+      reply: jest.fn()
+    };
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith('Online \u2705 Ping: 123ms');
+  });
+});

--- a/tests/commands/uptime.test.js
+++ b/tests/commands/uptime.test.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+import { execute } from '../../src/commands/uptime.js';
+
+describe('uptime command', () => {
+  test('responds with uptime in seconds', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(5000);
+    const interaction = {
+      client: { startTime: 0 },
+      reply: jest.fn()
+    };
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith('Bot uptime: 5 seconds.');
+  });
+});


### PR DESCRIPTION
## Summary
- add `/uptime` command to show how long the bot has been online
- add `/status` command that reports an online message with ping
- expose `startTime` in the Discord client for uptime
- document the new commands in the README
- add tests for both commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a35c016483288b37f08848b13fa7