### PR TITLE
Add meme and inspiration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ While developing you can run `npm run dev` so the bot restarts automatically whe
 - `/ping` – the bot replies "Pong!" and shows how long the response took.
 - `/help` – sends a list with all commands.
 - `/giff` – posts a random GIF just for fun.
+- `/meme` – replies with a random meme image.
+- `/inspiration` – shares an inspirational quote.
 - `/uptime` – shows how long the bot has been running.
 - `/status` – displays a simple online status with ping information.
 

--- a/src/commands/inspiration.js
+++ b/src/commands/inspiration.js
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+const quotes = [
+  'Believe in yourself and all that you are.',
+  'The only limit to our realization of tomorrow is our doubts of today.',
+  'You are never too old to set another goal or to dream a new dream.',
+  'Every day may not be good, but there is something good in every day.'
+];
+
+/**
+ * Defines the `/inspiration` command.
+ * It sends a random inspirational quote.
+ * @type {import('discord.js').SlashCommandBuilder}
+ */
+export const data = new SlashCommandBuilder()
+  .setName('inspiration')
+  .setDescription('Replies with an inspirational quote.');
+
+/**
+ * Runs when someone uses `/inspiration`.
+ * @param {import('discord.js').CommandInteraction} interaction
+ * @returns {Promise<void>}
+ */
+export async function execute(interaction) {
+  const index = Math.floor(Math.random() * quotes.length);
+  await interaction.reply(quotes[index]);
+}

--- a/src/commands/meme.js
+++ b/src/commands/meme.js
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+const memes = [
+  'https://i.imgflip.com/1bij.jpg',
+  'https://i.imgflip.com/26am.jpg',
+  'https://i.imgflip.com/3vzej.jpg',
+  'https://i.imgflip.com/30b1gx.jpg'
+];
+
+/**
+ * Defines the `/meme` command.
+ * It sends a random meme image URL.
+ * @type {import('discord.js').SlashCommandBuilder}
+ */
+export const data = new SlashCommandBuilder()
+  .setName('meme')
+  .setDescription('Replies with a random meme.');
+
+/**
+ * Runs when someone uses `/meme`.
+ * @param {import('discord.js').CommandInteraction} interaction
+ * @returns {Promise<void>}
+ */
+export async function execute(interaction) {
+  const index = Math.floor(Math.random() * memes.length);
+  await interaction.reply(memes[index]);
+}

--- a/tests/commands/inspiration.test.js
+++ b/tests/commands/inspiration.test.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+import { execute } from '../../src/commands/inspiration.js';
+
+describe('inspiration command', () => {
+  test('responds with an inspirational quote', async () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const interaction = { reply: jest.fn() };
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    const quote = interaction.reply.mock.calls[0][0];
+    expect(typeof quote).toBe('string');
+    expect(quote.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/commands/meme.test.js
+++ b/tests/commands/meme.test.js
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+import { execute } from '../../src/commands/meme.js';
+
+const MEME_REGEX = /^https:\/\/i\.imgflip\.com\/.+\.(jpg|png)$/;
+
+describe('meme command', () => {
+  test('responds with a meme url', async () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const interaction = { reply: jest.fn() };
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    const url = interaction.reply.mock.calls[0][0];
+    expect(MEME_REGEX.test(url)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/meme` command for sending a random meme URL
- add `/inspiration` command for sending a random inspirational quote
- document new commands in README
- test both new commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a7daf3308328bc582a858302e684